### PR TITLE
vault-plugin-secrets-apigee

### DIFF
--- a/website/content/docs/plugins/plugin-portal.mdx
+++ b/website/content/docs/plugins/plugin-portal.mdx
@@ -137,6 +137,7 @@ Plugin authors who wish to have their plugins listed may file a submission via a
 - [AWS Cognito](https://github.com/WealthWizardsEngineering/vault-plugin-secrets-cognito)
 - [Ethereum](https://github.com/immutability-io/vault-ethereum)
 - [GitHub](https://github.com/martinbaillie/vault-plugin-secrets-github)
+- [Google Apigee](https://github.com/bstraehle/vault-plugin-secrets-apigee)
 - [HydrantID PKI Plugin](https://github.com/PaddyPowerBetfair/vault-plugin-hydrant-pki)
 - [HSM PKI Plugin](https://github.com/mode51software/vaultplugin-hsmpki)
 - [OAuth 2.0/OIDC](https://github.com/puppetlabs/vault-plugin-secrets-oauthapp)


### PR DESCRIPTION
As per instructions at https://www.vaultproject.io/docs/plugins/plugin-portal, adding a community secrets plugin.